### PR TITLE
Add quotes to V1 vars

### DIFF
--- a/chart/status-cake-exporter/templates/deployment.yaml
+++ b/chart/status-cake-exporter/templates/deployment.yaml
@@ -26,11 +26,11 @@ spec:
         env:
 {{- if .Values.statuscake.useV1UptimeEndpoints }}
         - name: USE_V1_UPTIME_ENDPOINTS
-          value: {{ .Values.statuscake.useV1UptimeEndpoints }}
+          value: {{ .Values.statuscake.useV1UptimeEndpoints | quote }}
 {{- end }}
 {{- if .Values.statuscake.useV1MaintenanceWindowsEndpoints }}
         - name: USE_V1_MAINTENANCE_WINDOWS_ENDPOINTS
-          value: {{ .Values.statuscake.useV1MaintenanceWindowsEndpoints }}
+          value: {{ .Values.statuscake.useV1MaintenanceWindowsEndpoints | quote }}
 {{- end }}
         - name: USERNAME
           valueFrom:


### PR DESCRIPTION
Helm (via Flux's HelmRelease CRD) wasn't able to parse the boolean values for the V1 environment variables.  I've swapped to putting them in quotes, which parses fine and allows the helm chart to install.

A sample of the error:

```
Helm install failed: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found t, error found in #10 byte of ...|,"value":true},{"nam|..., bigger context ...|"env":[{"name":"USE_V1_UPTIME_ENDPOINTS","value":true},{"name":"USERNAME","valueFrom":{"secretKeyRef|...
```