### PR TITLE
Support tests with no performance data

### DIFF
--- a/status_cake_exporter/_status_cake.py
+++ b/status_cake_exporter/_status_cake.py
@@ -182,7 +182,10 @@ class StatusCake:
             # Fetch the performance of each test and add it to the response
             for test in response:
                 history = self.get_test_history(test["id"])
-                test["performance"] = history["data"][0]["performance"]
+                if history["data"]:
+                    test["performance"] = history["data"][0]["performance"]
+                else:
+                    logger.warning(f"No performance data found for test ID {test['id']}")
 
             print(response)
             return response


### PR DESCRIPTION
I had some issues where a test had no performance data. In this case its better to log a warning than to throw an exception