### PR TITLE
Support rate limits and missing performance data

### DIFF
--- a/status_cake_exporter/_test_collector.py
+++ b/status_cake_exporter/_test_collector.py
@@ -78,8 +78,7 @@ def transform(
 
     for i in tests:
         logger.debug(f"Transforming test id: {i['id']}")
-        t.append(
-            {
+        test = {
                 "test_id": str(i["id"]),
                 "test_type": str(
                     i["test_type"]
@@ -88,12 +87,14 @@ def transform(
                 "test_url": i["website_url"],
                 "test_status_int": get_uptime_status(i["status"]),
                 "test_uptime_percent": str(i["uptime"]),
-                "test_performance": str(i["performance"]),
                 "maintenance_status_int": get_test_maintenance_status(
                     i["id"], tests_in_maintenance
                 ),
             }
-        )
+        
+        if hasattr(i, 'performance'):
+            test["test_performance"]= str(i["performance"])
+        t.append(test)
         logger.debug(f"Transformed test id: {i['id']}")
 
     logger.debug(f"Test transformation complete. Returning {len(t)} metrics")
@@ -179,7 +180,8 @@ class TestCollector(Collector):
             )
 
             for i in metrics:
-                performance_gauge.add_metric([i["test_id"]], (i["test_performance"]))
+                if 'test_performance' in i.keys():
+                    performance_gauge.add_metric([i["test_id"]], (i["test_performance"]))
 
             yield performance_gauge
 


### PR DESCRIPTION
As mentioned in #13 , the statuscake API is pretty quick to rate limit requests. This checks the HTTP response code and adds a delay where required. Note that I have only implemented this on the performance-related endpoint for now, I had no issues being rate limited on the other endpoints.

It also includes a change to ignore performance data being absent for some tests - its normal for things like failed/paused tests to not have this field.
