### PR TITLE
Correctly pass any args to functions

### DIFF
--- a/status_cake_exporter/_status_cake.py
+++ b/status_cake_exporter/_status_cake.py
@@ -82,7 +82,7 @@ class StatusCake:
             list[dict[str, Any]]
         """
         params: DefaultPaginationParameters = {"page": 1, "limit": self.per_page}
-        args = args | params if args else params
+        params = args | params if args else params
 
         response = func(**params)
         metadata = response["metadata"]


### PR DESCRIPTION
I had some issues when filtering tests with a given tag and found that the `tags` parameter was being passed into the `__paginate_response` function correctly (as `args` ) but were never actually used. This fixes that