### PR TITLE
Fix broken metrics, make perf tests optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Options:
 | Name| Type | Description |
 |-----|------|-------------|
 | status_cake_test_info | Gauge |A basic listing of the tests under the current account. |
+| status_cake_test_status | Gauge | Current test status (1 is up, 0 is down) |
 | status_cake_test_uptime_percent | Gauge | Tests and their uptime percentage |
 | status_cake_test_performance | Gauge | Tests and their performance percentage |
 

--- a/README.md
+++ b/README.md
@@ -55,20 +55,29 @@ To get up and running quickly, use [examples/grafana-example.json](examples/graf
 Usage: status-cake-exporter [OPTIONS]
 
 Options:
-  --host TEXT            The host of the statuscake api.  [env var: HOST;
-                         default: https://api.statuscake.com/v1]
-  --api-key TEXT         API Key for the account.  [env var: API_KEY;
-                         required]
-  --tags TEXT            A comma separated list of tags used to filter tests
-                         returned from the api  [env var: TAGS]
-  --log-level TEXT       The log level of the application. Value can be one of
-                         {debug, info, warn, error}  [env var: LOG_LEVEL;
-                         default: info]
-  --port INTEGER         [env var: PORT; default: 8000]
-  --items-per-page TEXT  The number of items that the api will return on a
-                         page. This is a global option.  [env var:
-                         ITEMS_PER_PAGE; default: 25]
-  --help                 Show this message and exit
+  --host TEXT                     The host of the StatusCake API.  [env var:
+                                  HOST; default:
+                                  https://api.statuscake.com/v1]
+  --api-key TEXT                  API Key for the account.  [env var: API_KEY;
+                                  required]
+  --tags TEXT                     A comma separated list of tags used to
+                                  filter tests returned from the api  [env
+                                  var: TAGS]
+  --log-level TEXT                The log level of the application. Value can
+                                  be one of {debug, info, warn, error}  [env
+                                  var: LOG_LEVEL; default: info]
+  --port INTEGER                  [env var: PORT; default: 8000]
+  --enable-perf-metrics / --no-enable-perf-metrics
+                                  Enable the collection of test performance
+                                  times and expose as a metric. Warning - this
+                                  can cause additional usage of the statuscake
+                                  API and slow down runtime  [env var:
+                                  ENABLE_PERF_METRICS; default: no-enable-
+                                  perf-metrics]
+  --items-per-page TEXT           The number of items that the api will return
+                                  on a page. This is a global option.  [env
+                                  var: ITEMS_PER_PAGE; default: 25]
+  --help                          Show this message and exit.
 ```
 
 ## Metrics

--- a/status_cake_exporter/_status_cake.py
+++ b/status_cake_exporter/_status_cake.py
@@ -166,12 +166,13 @@ class StatusCake:
             logger.error(f"Error while fetching maintenance windows: {e}")
             raise e
 
-    def list_tests(self, tags: str = "") -> list[dict]:
+    def list_tests(self, tags: str = "", enable_perf_metrics: bool = False) -> list[dict]:
         """
         Returns a list of tests
 
         Args:
             tags: [str] A comma separated list of tags to filter by.
+            enable_perf_metrics: [bool] Enable collection of performance data.
 
         Returns:
             list[dict[str, Any]]
@@ -191,12 +192,13 @@ class StatusCake:
             )
 
             # Fetch the performance of each test and add it to the response
-            for test in response:
-                history = self.get_test_history(test["id"])
-                if history["data"]:
-                    test["performance"] = history["data"][0]["performance"]
-                else:
-                    logger.warning(f"No performance data found for test ID {test['id']}")
+            if enable_perf_metrics:
+                for test in response:
+                    history = self.get_test_history(test["id"])
+                    if history["data"]:
+                        test["performance"] = history["data"][0]["performance"]
+                    else:
+                        logger.warning(f"No performance data found for test ID {test['id']}")
 
             logger.debug(response)
             return response

--- a/status_cake_exporter/_test_collector.py
+++ b/status_cake_exporter/_test_collector.py
@@ -148,14 +148,14 @@ class TestCollector(Collector):
 
             # status_cake_test_info - gauge
             info_labels = ["test_id", "test_name", "test_type", "test_url"]
-            info_dict = { x:metrics[0][x] for x in info_labels}
             logger.info(f"Publishing {len(metrics)} test metric(s).")
             info_gauge = GaugeMetricFamily(
                 "status_cake_test_info",
                 "A basic listing of the tests under the current account.",
-                labels=list(info_dict.keys()),
+                labels=info_labels,
             )
             for i in metrics:
+                info_dict = { x:i[x] for x in info_labels}
                 # https://www.robustperception.io/why-info-style-metrics-have-a-value-of-1/
                 info_gauge.add_metric(list(info_dict.values()), 1.0)
 

--- a/status_cake_exporter/_test_collector.py
+++ b/status_cake_exporter/_test_collector.py
@@ -151,6 +151,8 @@ class TestCollector(Collector):
                 "status_cake_test_info",
                 "A basic listing of the tests under the current account.",
                 labels=list(metrics[0].keys()),
+                # info metrics should always be 1
+                value=1.0
             )
 
             for i in metrics:

--- a/status_cake_exporter/_test_collector.py
+++ b/status_cake_exporter/_test_collector.py
@@ -92,7 +92,6 @@ def transform(
                 ),
             }
         
-        print(f'test_status_int is {test["test_status_int"]} from {i["status"]}')
         if hasattr(i, 'performance'):
             test["test_performance"]= str(i["performance"])
         t.append(test)
@@ -105,7 +104,7 @@ def transform(
 class TestCollector(Collector):
     """The collector subclass responsible for gathering test metrics from the StatusCake API."""
 
-    def __init__(self, host: str, api_key: str, per_page: int, tags: str):
+    def __init__(self, host: str, api_key: str, per_page: int, tags: str, enable_perf_metrics: bool):
         """
         Args:
             host: [str] The host of the StatusCake API
@@ -117,6 +116,7 @@ class TestCollector(Collector):
         self.api_key: str = api_key
         self.per_page: int = per_page
         self.tags: str = tags
+        self.enable_perf_metrics: bool = enable_perf_metrics
 
     def collect(self):
         """
@@ -139,7 +139,7 @@ class TestCollector(Collector):
             )
 
             logger.debug("Fetching uptime tests")
-            tests = statuscake.list_tests(self.tags)
+            tests = statuscake.list_tests(self.tags, self.enable_perf_metrics)
 
             metrics = transform(tests, tests_in_maintenance)
             if len(metrics) == 0:

--- a/status_cake_exporter/app.py
+++ b/status_cake_exporter/app.py
@@ -30,6 +30,7 @@ def exporter(
         envvar="LOG_LEVEL",
     ),
     port: int = typer.Option(8000, envvar="PORT"),
+    enable_perf_metrics: bool = typer.Option(False, help="Enable the collection of test performance times and expose as a metric. Warning - this can cause additional usage of the statuscake API and slow down collection", envvar="ENABLE_PERF_METRICS"),
     items_per_page=typer.Option(
         25,
         help="The number of items that the api will return on a page. This is a global option.",
@@ -54,7 +55,7 @@ def exporter(
         start_http_server(port)
 
         logger.info("Registering collectors.")
-        test_collector = TestCollector(host, api_key, items_per_page, tags)
+        test_collector = TestCollector(host, api_key, items_per_page, tags, enable_perf_metrics)
         REGISTRY.register(test_collector)
 
         while True:


### PR DESCRIPTION
Apologies for dumping this into 1 PR, please see each commit for individual changes.

I've been trying to use the collector in a more realistic environment today and found a few issues which this PR addresses..

- the value of the `status_cake_test_info`  metric is now correctly set to 1 instead of 0 (see [here](https://www.robustperception.io/why-info-style-metrics-have-a-value-of-1/) for why), the current "uptime" state is now exposed via a new `status_cake_test_status` metric
- fixes the exposed value for the metric which tracks the current uptime state. It was always reporting 0 (!!)
- enables a generic retry mechanism on paginated API calls so that statuscake API rate limits are handled in a similar way as the non-paginated `get_test_history` calls
- disables the collection of performance metrics by default since it can slow down the collector significantly (this was discussed in #13)

You can see that now the performance data showing correctly in grafana..
![image](https://github.com/chelnak/status-cake-exporter/assets/138439698/0d4df9f8-2bc1-477d-8021-528d7f1d27ef)
