### PR TITLE
patch: adding ability to provide an existing secret with the username and API Key instead of hardcoding them

### DIFF
--- a/chart/status-cake-exporter/templates/_helpers.tpl
+++ b/chart/status-cake-exporter/templates/_helpers.tpl
@@ -25,3 +25,7 @@ Return the appropriate apiVersion for deployment.
 {{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "secretName" -}}
+{{ .Values.statuscake.existingSecret | default (printf "%s-api-token" .Release.Name) }}
+{{- end -}}

--- a/chart/status-cake-exporter/templates/deployment.yaml
+++ b/chart/status-cake-exporter/templates/deployment.yaml
@@ -35,12 +35,12 @@ spec:
         - name: USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-api-token
+              name: {{ include "secretName" . }}
               key: USERNAME
         - name: API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ .Release.Name }}-api-token
+              name: {{ include "secretName" . }}
               key: API_KEY
 {{- if .Values.statuscake.tags }}
         - name: TAGS

--- a/chart/status-cake-exporter/templates/secrets.yml
+++ b/chart/status-cake-exporter/templates/secrets.yml
@@ -1,8 +1,12 @@
+{{- if not .Values.statuscake.existingSecret }}
+{{- if not (or .Values.statuscake.username .Values.statuscake.apiKey)  }}
+{{- fail "Must provide a username and APIKey if you are not supplying an existing secret" }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ .Release.Name }}-api-token"
+  name: "{{ include "secretName" . }}"
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
@@ -12,3 +16,4 @@ type: generic
 data:
   USERNAME: {{ .Values.statuscake.username | b64enc }}
   API_KEY: {{ .Values.statuscake.apiKey | b64enc }}
+{{- end }}

--- a/chart/status-cake-exporter/values.yaml
+++ b/chart/status-cake-exporter/values.yaml
@@ -9,6 +9,9 @@ statuscake:
   # useV1UptimeEndpoints:
   # optional: a boolean format string for using the maintenance windows endpoints of the v1 API
   # useV1MaintenanceWindowsEndpoints:
+  # Supply an existing secret with the username and apiKey
+  # Secret must contain API_KEY and USERNAME
+  existingSecret: ~
   # REQUIRED: username to use when connecting to statuscake
   username: ""
   # REQUIRED: apikey to use when connecting to statuscake


### PR DESCRIPTION
As it stands we have to hard code the username and API key into the chart rather than being able to provide an existing secret.

This PR enables us to provide an existing secret for username and apikey. If an existing secret isn't supplied and a usename + apikey isn't supplied then the chart will error with a failure message saying it requires, at minimum, the username and apikey.